### PR TITLE
Personalize layout and design

### DIFF
--- a/quartz.config.ts
+++ b/quartz.config.ts
@@ -9,14 +9,14 @@ import * as Plugin from "./quartz/plugins"
 const config: QuartzConfig = {
   configuration: {
     pageTitle: "Jonas Philipps",
-    pageTitleSuffix: "",
+    pageTitleSuffix: " · Jonas Philipps",
     enableSPA: true,
     enablePopovers: true,
     analytics: {
       provider: "plausible",
     },
     locale: "en-US",
-    baseUrl: "quartz.jzhao.xyz",
+    baseUrl: "sterafix.github.io",
     ignorePatterns: ["private", "templates", ".obsidian"],
     defaultDateType: "modified",
     // NACHHER:

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -22,7 +22,10 @@ export const defaultContentPageLayout: PageLayout = {
       condition: (page) => page.fileData.slug !== "index",
     }),
     Component.ArticleTitle(),
-    Component.ContentMeta(),
+    Component.ConditionalRender({
+      component: Component.ContentMeta(),
+      condition: (page) => page.fileData.slug !== "index",
+    }),
     Component.TagList(),
   ],
   left: [
@@ -41,7 +44,6 @@ export const defaultContentPageLayout: PageLayout = {
     Component.Explorer(),
   ],
   right: [
-    Component.Graph(),
     Component.DesktopOnly(Component.TableOfContents()),
     Component.Backlinks(),
   ],

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -22,10 +22,7 @@ export const defaultContentPageLayout: PageLayout = {
       condition: (page) => page.fileData.slug !== "index",
     }),
     Component.ArticleTitle(),
-    Component.ConditionalRender({
-      component: Component.ContentMeta(),
-      condition: (page) => page.fileData.slug !== "index",
-    }),
+    Component.ContentMeta(),
     Component.TagList(),
   ],
   left: [

--- a/quartz/styles/custom.scss
+++ b/quartz/styles/custom.scss
@@ -131,3 +131,15 @@ hr {
   border: none;
   border-top: 1px solid var(--lightgray);
 }
+
+
+// ─── Homepage ─────────────────────────────────────────────────────────────────
+
+body[data-slug="index"] article p {
+  font-size: 1.05rem;
+  line-height: 1.85;
+}
+
+body[data-slug="index"] article {
+  padding-top: 2rem;
+}


### PR DESCRIPTION
- Fix baseUrl from quartz.jzhao.xyz to sterafix.github.io (fixes OG images, RSS, sitemap)
- Add pageTitleSuffix ' · Jonas Philipps' for browser tab context
- Remove Graph component from right sidebar (too sparse to be useful)
- (planned at first, but then not implemented: Hide ContentMeta (modified date) on homepage via ConditionalRender)
- Increase font size and padding on homepage for better readability

https://claude.ai/code/session_01TLPMLsZyotR22cWawPyD3T