### PR TITLE
Remove search bar and reader mode button from sidebar

### DIFF
--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -28,12 +28,7 @@ export const defaultContentPageLayout: PageLayout = {
   left: [
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
-    Component.Flex({
-      components: [
-        { Component: Component.Darkmode() },
-        { Component: Component.ReaderMode() },
-      ],
-    }),
+    Component.Darkmode(),
     Component.Explorer(),
   ],
   right: [
@@ -49,11 +44,7 @@ export const defaultListPageLayout: PageLayout = {
   left: [
     Component.PageTitle(),
     Component.MobileOnly(Component.Spacer()),
-    Component.Flex({
-      components: [
-        { Component: Component.Darkmode() },
-      ],
-    }),
+    Component.Darkmode(),
     Component.Explorer(),
   ],
   right: [],

--- a/quartz.layout.ts
+++ b/quartz.layout.ts
@@ -30,10 +30,6 @@ export const defaultContentPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Flex({
       components: [
-        {
-          Component: Component.Search(),
-          grow: true,
-        },
         { Component: Component.Darkmode() },
         { Component: Component.ReaderMode() },
       ],
@@ -55,10 +51,6 @@ export const defaultListPageLayout: PageLayout = {
     Component.MobileOnly(Component.Spacer()),
     Component.Flex({
       components: [
-        {
-          Component: Component.Search(),
-          grow: true,
-        },
         { Component: Component.Darkmode() },
       ],
     }),


### PR DESCRIPTION
## Changes

- **Remove search bar**: unnecessary for a small personal site with few pages.
- **Remove reader mode button**: had no visible effect.
- `Darkmode` toggle now sits directly in the left panel — no `Flex` wrapper needed.